### PR TITLE
Fix README.md to include installing the board and libraries required

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Buy the units here: https://www.aliexpress.com/item/1005006038630745.html
 
 https://www.aliexpress.com/item/1005006038630745.html
 
+## Arduino IDE Setup
+
+Before uploading the firmware, you need to install the ESP8266 board support in Arduino IDE:
+
+1. Start Arduino and open the Preferences window
+2. Enter `https://arduino.esp8266.com/stable/package_esp8266com_index.json` into the **File > Preferences > Additional Boards Manager URLs** field of the Arduino IDE. You can add multiple URLs, separating them with commas.
+3. Open **Boards Manager** from **Tools > Board** menu and install **esp8266** platform (and don't forget to select your ESP8266 board from **Tools > Board** menu after installation).
+
+## Required Libraries
+
+Install the following libraries via **Sketch > Include Library > Manage Libraries**:
+
+1. **WiFiManager** by tzapu
+2. **MD_Parola** by MajicDesigns
+3. **MD_MAX72XX** by MajicDesigns
+
+After installing these libraries, you should be able to compile and upload the firmware.
+
 ## Connecting to Wi-Fi / Companion
 
 The device boots and attempts Wi-Fi and Companion automatically.


### PR DESCRIPTION
## 🚀 What’s in this PR?

This update adds some much-needed setup instructions so folks can actually compile the firmware without the Arduino IDE throwing a tantrum about missing libraries.  

Think of it as giving users a map *before* dropping them in the wilderness.

---

## 🔧 What Changed?

- Added a shiny new **Arduino IDE Setup** section so people can install ESP8266 board support without guessing or summoning dark forces.  
- Added a **Required Libraries** list featuring the legendary trio:
  - **WiFiManager**
  - **MD_Parola**
  - **MD_MAX72XX**  
  Each includes a quick “here’s how to install it before everything catches fire” guide.

---

## 🤔 Why Bother?

Because nothing says “fun weekend project” like endless compiler errors about libraries you didn’t know existed.  
These instructions now sit neatly after the Hardware section and before the connection steps, giving users a chance to set everything up *before* uploading code and wondering why the universe is against them.

---

## 🧪 Testing Notes

- Verified every step against the current codebase  
- Confirmed library names match the `#include` statements (no surprises hiding there)  

All up, it should make setup smoother, reduce head-scratching, and help users get up and running without rage-quitting.

---